### PR TITLE
fix backup command

### DIFF
--- a/images/opendexd/opendexd-backup.sh
+++ b/images/opendexd/opendexd-backup.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
-./bin/opendexd-backup -b /root/backup
+XUD_BACKUP_DIR="${XUD_BACKUP_DIR:-/root/backup}"
+echo "[backup] Initiating backup to $XUD_BACKUP_DIR..."
+./bin/opendex-backup -b $XUD_BACKUP_DIR


### PR DESCRIPTION
Actual path: https://github.com/opendexnetwork/opendexd/blob/main/bin/opendex-backup

Also allows overriding default location with env var `XUD_BACKUP_DIR`.