### PR TITLE
feat: add --nopull option to setup command

### DIFF
--- a/launcher/cmd/setup.go
+++ b/launcher/cmd/setup.go
@@ -5,7 +5,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type SetupOptions struct {
+	NoPull bool
+}
+
+var (
+	setupOpts SetupOptions
+)
+
 func init() {
+	setupCmd.PersistentFlags().BoolVar(&setupOpts.NoPull, "nopull", false, "don't pull images")
 	rootCmd.AddCommand(setupCmd)
 }
 
@@ -19,6 +28,6 @@ var setupCmd = &cobra.Command{
 		ctx, cancel := newContext()
 		defer cancel()
 		ctx = context.WithValue(ctx, "rescue", false)
-		return launcher.Setup(ctx)
+		return launcher.Setup(ctx, !setupOpts.NoPull)
 	},
 }

--- a/launcher/core/setup.go
+++ b/launcher/core/setup.go
@@ -38,7 +38,7 @@ func (t *Launcher) Pull(ctx context.Context) error {
 	return utils.Run(ctx, cmd)
 }
 
-func (t *Launcher) Setup(ctx context.Context) error {
+func (t *Launcher) Setup(ctx context.Context, pull bool) error {
 	t.Logger.Debugf("Setup %s (%s)", t.Network, t.NetworkDir)
 
 	// Checking Docker
@@ -73,8 +73,10 @@ func (t *Launcher) Setup(ctx context.Context) error {
 		return fmt.Errorf("generate files: %w", err)
 	}
 
-	if err := t.Pull(ctx); err != nil {
-		return fmt.Errorf("pull: %w", err)
+	if pull {
+		if err := t.Pull(ctx); err != nil {
+			return fmt.Errorf("pull: %w", err)
+		}
 	}
 
 	t.Logger.Debugf("Bring up proxy")


### PR DESCRIPTION
This PR adds "--nopull" option to disabe pulling new images during setup. It's useful when you need to test your local built images.

