### PR TITLE
feat: implement attach command

### DIFF
--- a/launcher/core/attach.go
+++ b/launcher/core/attach.go
@@ -1,5 +1,77 @@
 package core
 
-func (t *Launcher) Attach() error {
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"github.com/gorilla/websocket"
+	"github.com/opendexnetwork/opendex-docker/launcher/service/proxy"
+	"net/url"
+	"os"
+	"os/signal"
+	"time"
+)
+
+func (t *Launcher) Attach(endpoint string) error {
+	// TODO implement here
+	// supports ws and wss
 	return nil
+}
+
+func (t *Launcher) attachToProxy(ctx context.Context) error {
+	interrupt := make(chan os.Signal, 1)
+	signal.Notify(interrupt, os.Interrupt)
+
+	s, err := t.GetService("proxy")
+	if err != nil {
+		return err
+	}
+
+	params, err := s.GetRpcParams()
+	if err != nil {
+		return err
+	}
+
+	port := params.(proxy.RpcParams).Port
+
+	u := url.URL{Scheme: "wss", Host: fmt.Sprintf("127.0.0.1:%d", port), Path: "/launcher"}
+	t.Logger.Debugf("Connecting to %s", u.String())
+
+	config := tls.Config{RootCAs: nil, InsecureSkipVerify: true}
+
+	dialer := websocket.DefaultDialer
+	dialer.TLSClientConfig = &config
+	c, _, err := dialer.Dial(u.String(), nil)
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+
+	t.Logger.Debugf("Attached to proxy")
+
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		t.serve(ctx, c)
+	}()
+
+	for {
+		select {
+		case <-done:
+			return nil
+		case <-interrupt:
+			t.Logger.Debugf("Interrupted")
+			err := c.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+			if err != nil {
+				t.Logger.Errorf("write close: %s", err)
+				return nil
+			}
+			select {
+			case <-done:
+			case <-time.After(time.Second):
+			}
+			return nil
+		}
+	}
 }

--- a/launcher/core/setup.go
+++ b/launcher/core/setup.go
@@ -3,19 +3,15 @@ package core
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/gorilla/websocket"
 	"github.com/opendexnetwork/opendex-docker/launcher/service/proxy"
 	"github.com/opendexnetwork/opendex-docker/launcher/utils"
 	"golang.org/x/sync/errgroup"
 	"net/http"
-	"net/url"
 	"os"
 	"os/exec"
-	"os/signal"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -365,64 +361,6 @@ func (t *Launcher) upBoltz(ctx context.Context) error {
 	return t.upService(ctx, "boltz", func(status string) bool {
 		return true
 	})
-}
-
-func (t *Launcher) attachToProxy(ctx context.Context) error {
-	interrupt := make(chan os.Signal, 1)
-	signal.Notify(interrupt, os.Interrupt)
-
-	s, err := t.GetService("proxy")
-	if err != nil {
-		return err
-	}
-
-	params, err := s.GetRpcParams()
-	if err != nil {
-		return err
-	}
-
-	port := params.(proxy.RpcParams).Port
-
-	u := url.URL{Scheme: "wss", Host: fmt.Sprintf("127.0.0.1:%d", port), Path: "/launcher"}
-	t.Logger.Debugf("Connecting to %s", u.String())
-
-	config := tls.Config{RootCAs: nil, InsecureSkipVerify: true}
-
-	dialer := websocket.DefaultDialer
-	dialer.TLSClientConfig = &config
-	c, _, err := dialer.Dial(u.String(), nil)
-	if err != nil {
-		return err
-	}
-	defer c.Close()
-
-	t.Logger.Debugf("Attached to proxy")
-
-	done := make(chan struct{})
-
-	go func() {
-		defer close(done)
-		t.serve(ctx, c)
-	}()
-
-	for {
-		select {
-		case <-done:
-			return nil
-		case <-interrupt:
-			t.Logger.Debugf("Interrupted")
-			err := c.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
-			if err != nil {
-				t.Logger.Errorf("write close: %s", err)
-				return nil
-			}
-			select {
-			case <-done:
-			case <-time.After(time.Second):
-			}
-			return nil
-		}
-	}
 }
 
 func (t *Launcher) upLayer2(ctx context.Context) error {


### PR DESCRIPTION
This PR implements the `attach` command which can be used like

```
./opendex-launcher attach ws://127.0.0.1:8080
```

It's useful when you debugging proxy (opendex-docker-api) locally.
