### PR TITLE
feat: bring back updates checking logic

### DIFF
--- a/launcher/core/launcher.go
+++ b/launcher/core/launcher.go
@@ -59,6 +59,8 @@ type Launcher struct {
 	rootLogger *logrus.Logger
 
 	LogFile *os.File
+
+	ShowUpdateDetails bool
 }
 
 func defaultHomeDir() (string, error) {
@@ -228,6 +230,7 @@ func NewLauncher() (*Launcher, error) {
 			},
 		},
 		LogFile: f,
+		ShowUpdateDetails: true,
 	}
 
 	l.Services, l.ServicesOrder, err = initServices(&l, network)

--- a/launcher/core/update.go
+++ b/launcher/core/update.go
@@ -3,9 +3,60 @@ package core
 import (
 	"context"
 	"fmt"
+	"github.com/opendexnetwork/opendex-docker/launcher/utils"
 )
 
-func (t *Launcher) Update(ctx context.Context) {
-	// TODO update
-	fmt.Println("to be implemented")
+type ImageUpdate struct {
+	Name string
+	OldDigest string
+	OldCreated string
+	NewDigest string
+	NewCreated string
+}
+
+type ContainerUpdate struct {
+	Name string
+	Action string
+}
+
+type UpdateDetails struct {
+	Images []ImageUpdate
+	Containers []ContainerUpdate
+}
+
+func (t *Launcher) Update(ctx context.Context, noConfirmation bool) error {
+	details := t.checkForUpdates(ctx)
+	if details == nil {
+		fmt.Println("All up-to-date.")
+		return nil
+	}
+	if t.ShowUpdateDetails {
+		fmt.Println(details)
+	}
+	if !noConfirmation {
+		reply := utils.YesNo("Do you want to upgrade?", utils.YES)
+		if reply == utils.NO {
+			return nil
+		}
+	}
+	return t.applyUpdates(details)
+}
+
+func (t *Launcher) applyUpdates(details *UpdateDetails) error {
+	return nil
+}
+
+func (t *Launcher) checkForUpdates(ctx context.Context) *UpdateDetails {
+	return &UpdateDetails{
+		Images: t.checkForImageUpdates(ctx),
+		Containers: t.checkForContainerUpdates(ctx),
+	}
+}
+
+func (t *Launcher) checkForImageUpdates(ctx context.Context) []ImageUpdate {
+	return nil
+}
+
+func (t *Launcher) checkForContainerUpdates(ctx context.Context) []ContainerUpdate {
+	return nil
 }

--- a/launcher/utils/cli.go
+++ b/launcher/utils/cli.go
@@ -1,0 +1,38 @@
+package utils
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Answer string
+
+const (
+	YES Answer = "yes"
+	NO Answer = "no"
+)
+
+func YesNo(question string, defaultAnswer Answer) Answer {
+	var reply string
+	for {
+		switch defaultAnswer {
+		case YES:
+			fmt.Println(question + " [Y/n] ")
+		case NO:
+			fmt.Println(question + " [y/N] ")
+		}
+		_, err := fmt.Scanln(&reply)
+		if err != nil {
+			panic(err)
+		}
+		reply = strings.TrimSpace(reply)
+		reply = strings.ToLower(reply)
+		if reply == "y" || reply == "yes" {
+			return YES
+		} else if reply == "n" || reply == "no" {
+			return NO
+		} else if reply == "" {
+			return defaultAnswer
+		}
+	}
+}


### PR DESCRIPTION
This PR brings back the original updates checking logic. It includes checking of images and containers. The containers update checking is the most tricky part when using docker-compose.

This PR also provides a separate subcommand "update" to just update. I can be used like:

```
opendex-launcher update
opendex-launcher update -y # --yes without confirmation question
```

This is also a prerequisite PR for interactive setup. In **interactive** setup, it will invoke `update`; in **non-interactive** setup, it will invoke `update -y`. And you could specify `--noupdates` to turn off updates checking in setup.

