### PR TITLE
feat: interactive setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
     name: Build binary launcher
     strategy:
       matrix:
-        go-version: [ 1.15.x ]
+        go-version: [ 1.16.x ]
         os: [ linux, darwin, windows ]
         arch: [ amd64, arm64 ]
         exclude:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
     name: Build artifacts
     strategy:
       matrix:
-        go-version: [ 1.15.x ]
+        go-version: [ 1.16.x ]
         os: [ linux, darwin, windows ]
         arch: [ amd64, arm64 ]
         exclude:

--- a/launcher/cmd/console.go
+++ b/launcher/cmd/console.go
@@ -1,3 +1,23 @@
 package cmd
 
-// TODO console
+import (
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(consoleCmd)
+}
+
+var consoleCmd = &cobra.Command{
+	Use:   "console",
+	Short: "Start the console",
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		return launcher.Apply()
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx, cancel := newContext()
+		defer cancel()
+		return launcher.StartConsole(ctx)
+	},
+}
+

--- a/launcher/cmd/setup.go
+++ b/launcher/cmd/setup.go
@@ -7,6 +7,7 @@ import (
 
 type SetupOptions struct {
 	NoPull bool
+	Interactive bool
 }
 
 var (
@@ -15,6 +16,7 @@ var (
 
 func init() {
 	setupCmd.PersistentFlags().BoolVar(&setupOpts.NoPull, "nopull", false, "don't pull images")
+	setupCmd.PersistentFlags().BoolVarP(&setupOpts.Interactive, "interactive", "i", false, "interactive setup")
 	rootCmd.AddCommand(setupCmd)
 }
 
@@ -28,6 +30,6 @@ var setupCmd = &cobra.Command{
 		ctx, cancel := newContext()
 		defer cancel()
 		ctx = context.WithValue(ctx, "rescue", false)
-		return launcher.Setup(ctx, !setupOpts.NoPull)
+		return launcher.Setup(ctx, !setupOpts.NoPull, setupOpts.Interactive)
 	},
 }

--- a/launcher/core/console/bash.go
+++ b/launcher/core/console/bash.go
@@ -1,0 +1,196 @@
+package console
+
+import (
+	"github.com/sirupsen/logrus"
+	"os"
+	"os/exec"
+)
+
+var logger = logrus.NewEntry(logrus.StandardLogger())
+
+var help = `\
+Xucli shortcut commands
+  addcurrency <currency>                    add a currency
+  <swap_client> [decimal_places]
+  [token_address]
+  addpair <pair_id|base_currency>           add a trading pair
+  [quote_currency]
+  ban <node_identifier>                     ban a remote node
+  buy <quantity> <pair_id> <price>          place a buy order
+  [order_id]
+  closechannel <currency>                   close any payment channels with a
+  [node_identifier ] [--force]              peer
+  connect <node_uri>                        connect to a remote node
+  create                                    create a new opendexd instance and set a
+                                            password
+  discovernodes <node_identifier>           discover nodes from a specific peer
+  getbalance [currency]                     get total balance for a given
+                                            currency
+  getinfo                                   get general info from the local opendexd
+                                            node
+  getnodeinfo <node_identifier>             get general information about a
+                                            known node
+  listcurrencies                            list available currencies
+  listorders [pair_id] [owner]              list orders from the order book
+  [limit]
+  listpairs                                 get order book's available pairs
+  listpeers                                 list connected peers
+  openchannel <currency> <amount>           open a payment channel with a peer
+  [node_identifier] [push_amount]
+  orderbook [pair_id] [precision]           display the order book, with orders
+                                            aggregated per price point
+  removecurrency <currency>                 remove a currency
+  removeorder <order_id> [quantity]         remove an order
+  removepair <pair_id>                      remove a trading pair
+  restore [backup_directory]                restore an opendexd instance from seed
+  sell <quantity> <pair_id> <price>         place a sell order
+  [order_id]
+  shutdown                                  gracefully shutdown local opendexd node
+  streamorders [existing]                   stream order added, removed, and
+                                            swapped events (DEMO)
+  tradehistory [limit]                      list completed trades
+  tradinglimits [currency]                  trading limits for a given currency
+  unban <node_identifier>                   unban a previously banned remote
+  [--reconnect]                             node
+  unlock                                    unlock local opendexd node
+  walletdeposit <currency>                  gets an address to deposit funds to
+                                            opendexd
+  walletwithdraw [amount] [currency]        withdraws on-chain funds from opendexd
+  [destination] [fee]
+  
+General commands
+  report                                    report issue
+  logs                                      show service log
+  start                                     start service
+  stop                                      stop service
+  restart                                   restart service
+  up                                        bring up the environment
+  help                                      show this help
+  exit                                      exit opendexd-ctl shell
+
+CLI commands
+  bitcoin-cli                               bitcoind cli
+  litecoin-cli                              litecoind cli
+  lndbtc-lncli                              lnd cli
+  lndltc-lncli                              lnd cli
+  geth                                      geth cli
+  opendex-cli                                     opendexd cli
+  boltzcli                                  boltz cli
+
+Boltzcli shortcut commands  
+  boltzcli <chain> deposit 
+  --inbound [inbound_balance]               deposit from boltz (btc/ltc)
+  boltzcli <chain> withdraw 
+  <amount> <address>                        withdraw from boltz channel
+`
+
+func writeInitScript(network string, f *os.File) {
+	f.WriteString(`\
+export NETWORK=` + network + `
+export PS1="$NETWORK > "
+function help() {
+	echo "` + help + `"
+}
+function start() {
+	docker start ${NETWORK}_${1}_1 
+}
+function stop() {
+	docker stop ${NETWORK}_${1}_1
+}
+function restart() {
+	docker restart ${NETWORK}_${1}_1
+}
+function down() {
+	echo "Not implemented yet!"
+}
+function logs() {
+	docker logs --tail=100 ${NETWORK}_${1}_1
+}
+function report() {
+	cat <<EOF
+Please click on https://github.com/opendexnetwork/opendexd/issues/\
+new?assignees=kilrau&labels=bug&template=bug-report.md&title=Short%2C+concise+\
+description+of+the+bug, describe your issue, drag and drop the file "${NETWORK}\
+.log" which is located in "{logs_dir}" into your browser window and submit \
+your issue.
+EOF
+}
+function opendex-cli() {
+	docker exec -it ${NETWORK}_opendexd_1 opendex-cli $@
+}
+function lndbtc-lncli() {
+	docker exec -it ${NETWORK}_lndbtc_1 lncli -n ${NETWORK} -c bitcoin $@
+}
+function lndltc-lncli() {
+	docker exec -it ${NETWORK}_lndltc_1 lncli -n ${NETWORK} -c litecoin $@
+}
+function geth() {
+	docker exec -it ${NETWORK}_geth_1 geth $@
+}
+function bitcoin-ctl() {	
+	if [[ $NETWORK == "testnet" ]]; then
+		docker exec -it ${NETWORK}_bitcoind_1 -testnet -user xu -password xu bitcoind $@
+	else
+		docker exec -it ${NETWORK}_bitcoind_1 -user xu -password xu bitcoind $@
+	fi
+}
+function litecoin-ctl() {
+	if [[ $NETWORK == "testnet" ]]; then
+		docker exec -it ${NETWORK}_litecoind_1 -testnet -user xu -password xu litecoind $@
+	else
+		docker exec -it ${NETWORK}_litecoind_1 -user xu -password xu litecoind $@
+	fi
+}
+function boltzcli() {
+	docker exec -it ${NETWORK}_boltz_1 wrapper $@
+}
+
+alias getinfo='opendex-cli getinfo'
+alias addcurrency='opendex-cli addcurrency'
+alias addpair='opendex-cli addpair'
+alias ban='opendex-cli ban'
+alias buy='opendex-cli buy'
+alias closechannel='opendex-cli closechannel'
+alias connect='opendex-cli connect'
+alias create='opendex-cli create'
+alias discovernodes='opendex-cli discovernodes'
+alias getbalance='opendex-cli getbalance'
+alias getnodeinfo='opendex-cli getnodeinfo'
+alias listcurrencies='opendex-cli listcurrencies'
+alias listorders='opendex-cli listorders'
+alias listpairs='opendex-cli listpairs'
+alias listpeers='opendex-cli listpeers'
+alias openchannel='opendex-cli openchannel'
+alias orderbook='opendex-cli orderbook'
+alias removeallorders='opendex-cli removeallorders'
+alias removecurrency='opendex-cli removecurrency'
+alias removeorder='opendex-cli removeorder'
+alias removepair='opendex-cli removepair'
+alias restore='opendex-cli restore'
+alias sell='opendex-cli sell'
+alias shutdown='opendex-cli shutdown'
+alias streamorders='opendex-cli streamorders'
+alias tradehistory='opendex-cli tradehistory'
+alias tradinglimits='opendex-cli tradinglimits'
+alias unban='opendex-cli unban'
+alias unlock='opendex-cli unlock'
+alias walletdeposit='opendex-cli walletdeposit'
+alias walletwithdraw='opendex-cli walletwithdraw'
+`)
+}
+
+func startBash() error {
+	network := os.Getenv("NETWORK")
+	f, err := os.CreateTemp(os.TempDir(), "init.*.bash")
+	if err != nil {
+		logger.Errorf("Failed to write init.bash: %s", err)
+		return nil
+	}
+	defer f.Close()
+	writeInitScript(network, f)
+	c := exec.Command("bash", "--init-file", f.Name())
+	c.Stdin = os.Stdin
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	return c.Run()
+}

--- a/launcher/core/console/console.go
+++ b/launcher/core/console/console.go
@@ -1,0 +1,43 @@
+package console
+
+import (
+	"fmt"
+	"runtime"
+)
+
+const (
+	DefaultBanner = `
+             .___                         __  .__   
+           __| _/____ ___  ___      _____/  |_|  |  
+          / __ |/ __ \\  \/  /    _/ ___\   __\  |  
+         / /_/ \  ___/ >    <     \  \___|  | |  |__
+         \____ |\___  >__/\_ \     \___  >__| |____/
+              \/    \/      \/         \/           
+
+--------------------------------------------------------------
+`)
+
+type Console struct {
+	Banner string
+	ShowBanner bool
+}
+
+var DefaultConsole *Console
+
+func init() {
+	DefaultConsole = &Console{
+		Banner: DefaultBanner,
+		ShowBanner: true,
+	}
+}
+
+func (t *Console) Start() error {
+	if t.ShowBanner {
+		fmt.Println(t.Banner)
+	}
+	if runtime.GOOS == "windows" {
+		return startPowershell()
+	} else {
+		return startBash()
+	}
+}

--- a/launcher/core/console/powershell.go
+++ b/launcher/core/console/powershell.go
@@ -1,0 +1,5 @@
+package console
+
+func startPowershell() error {
+	return nil
+}

--- a/launcher/core/launcher.go
+++ b/launcher/core/launcher.go
@@ -2,11 +2,13 @@ package core
 
 import (
 	"bufio"
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
 	"github.com/iancoleman/strcase"
 	"github.com/mitchellh/go-homedir"
+	"github.com/opendexnetwork/opendex-docker/launcher/core/console"
 	"github.com/opendexnetwork/opendex-docker/launcher/log"
 	"github.com/opendexnetwork/opendex-docker/launcher/service/arby"
 	"github.com/opendexnetwork/opendex-docker/launcher/service/bitcoind"
@@ -59,6 +61,8 @@ type Launcher struct {
 	rootLogger *logrus.Logger
 
 	LogFile *os.File
+
+	Console *console.Console
 }
 
 func defaultHomeDir() (string, error) {
@@ -244,6 +248,7 @@ func NewLauncher() (*Launcher, error) {
 			},
 		},
 		LogFile: f,
+		Console: console.DefaultConsole,
 	}
 
 	l.Services, l.ServicesOrder, err = initServices(&l, network)
@@ -544,4 +549,8 @@ func (t *Launcher) GetDataDir() string {
 
 func (t *Launcher) Close() {
 	_ = t.LogFile.Close()
+}
+
+func (t *Launcher) StartConsole(ctx context.Context) error {
+	return t.Console.Start()
 }

--- a/launcher/core/launcher.go
+++ b/launcher/core/launcher.go
@@ -53,6 +53,7 @@ type Launcher struct {
 	ConfigFile        string
 
 	PasswordUnsetMarker string
+	BackupUnsetMarker   string
 	ExternalIp          string
 
 	rootCmd *cobra.Command
@@ -212,6 +213,7 @@ func NewLauncher() (*Launcher, error) {
 			return nil, err
 		}
 	}
+	backupUnsetMarker := filepath.Join(networkDir, ".backup-unset")
 
 	backupDir := getBackupDir(networkDir, dockerComposeFile)
 	defaultBackupDir := getDefaultBackupDir(networkDir)
@@ -241,6 +243,7 @@ func NewLauncher() (*Launcher, error) {
 		DockerComposeFile:   dockerComposeFile,
 		ConfigFile:          configFile,
 		PasswordUnsetMarker: passwordUnsetMarker,
+		BackupUnsetMarker:   backupUnsetMarker,
 		ExternalIp:          externalIp,
 		client: &http.Client{
 			Transport: &http.Transport{

--- a/launcher/core/setup.go
+++ b/launcher/core/setup.go
@@ -38,7 +38,7 @@ func (t *Launcher) Pull(ctx context.Context) error {
 	return utils.Run(ctx, cmd)
 }
 
-func (t *Launcher) Setup(ctx context.Context, pull bool) error {
+func (t *Launcher) Setup(ctx context.Context, pull bool, interactive bool) error {
 	t.Logger.Debugf("Setup %s (%s)", t.Network, t.NetworkDir)
 
 	// Checking Docker

--- a/launcher/core/setup.go
+++ b/launcher/core/setup.go
@@ -39,6 +39,9 @@ func (t *Launcher) Pull(ctx context.Context) error {
 }
 
 func (t *Launcher) Setup(ctx context.Context, pull bool, interactive bool) error {
+	if interactive {
+		fmt.Printf("🚀 Launching %s environment\n", t.Network)
+	}
 	t.Logger.Debugf("Setup %s (%s)", t.Network, t.NetworkDir)
 
 	// Checking Docker
@@ -71,6 +74,10 @@ func (t *Launcher) Setup(ctx context.Context, pull bool, interactive bool) error
 
 	if err := t.Gen(ctx); err != nil {
 		return fmt.Errorf("generate files: %w", err)
+	}
+
+	if interactive {
+		fmt.Printf("🌍 Checking for updates ...\n")
 	}
 
 	if pull {
@@ -119,8 +126,13 @@ func (t *Launcher) Setup(ctx context.Context, pull bool, interactive bool) error
 	}
 	_ = f.Close()
 
-	fmt.Println("Attached to proxy. Press Ctrl-C to detach from it.")
-	wg.Wait()
+	if interactive {
+		// enter into console
+		return t.StartConsole(ctx)
+	} else {
+		fmt.Println("Attached to proxy. Press Ctrl-C to detach from it.")
+		wg.Wait()
+	}
 
 	return nil
 }
@@ -325,6 +337,15 @@ func (t *Launcher) upService(ctx context.Context, name string, checkFunc func(st
 }
 
 func (t *Launcher) upOpendexd(ctx context.Context) error {
+	// Do you want to create a new opendexd environment or restore an existing one?
+	//1) Create New
+	//2) Restore Existing
+	//Please choose: 1
+
+	// Please enter a path to a destination where to store a backup of your environment. It includes everything, but NOT your on-chain wallet balance which is secured by your opendexd SEED. The path should be an external drive, like a USB or network drive, which is permanently available on your device since backups are written constantly.
+	//
+	//Enter path to backup location: /media/USB/
+	//Checking... OK.
 	return t.upService(ctx, "opendexd", func(status string) bool {
 		if status == "Ready" {
 			return true

--- a/opendex.sh
+++ b/opendex.sh
@@ -1,3 +1,31 @@
-#!/bin/bash
+#!/bin/sh
 
-echo "to be implemented"
+set -e
+
+OPENDEX_LAUNCHER_VERSION="v1.0.0-rc.3"
+
+# ensure the opendex-launcher binary is downloaded
+# select the network
+# run opendex-launcher setup --interactive
+
+if [ "$(uname)" = "Darwin" ]; then
+  OPENDEX_DOCKER_HOME="$HOME/Library/Application\ Support/OpendexDocker"
+else
+  OPENDEX_DOCKER_HOME="$HOME/.opendex-docker"
+fi
+
+if ! [ -e "$OPENDEX_DOCKER_HOME" ]; then
+  mkdir "$OPENDEX_DOCKER_HOME"
+fi
+
+ensure_launcher() {
+  :
+}
+
+ensure_network() {
+  :
+}
+
+ensure_launcher
+ensure_network
+$LAUNCHER setup --interactive

--- a/opendex.sh
+++ b/opendex.sh
@@ -36,4 +36,5 @@ ensure_network() {
 
 ensure_launcher
 ensure_network
+export NETWORK=$NETWORK
 $LAUNCHER setup --interactive

--- a/opendex.sh
+++ b/opendex.sh
@@ -19,11 +19,19 @@ if ! [ -e "$OPENDEX_DOCKER_HOME" ]; then
 fi
 
 ensure_launcher() {
-  :
+  LAUNCHER=${LAUNCHER:-"/usr/bin/opendex-launcher"}
 }
 
 ensure_network() {
-  :
+  while [ -z "${NETWORK:-}" ]; do
+    echo "1) Testnet"
+    echo "2) Mainnet"
+    read -r -p "Please choose the network: "
+    case $REPLY in
+      1) NETWORK="testnet";;
+      2) NETWORK="mainnet";;
+    esac
+  done
 }
 
 ensure_launcher


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

This PR brings old xud-docker CLI interactive setup flow back.

#### Network selection
```
1) Testnet
2) Mainnet
Please choose the network:
```

#### Update checking
```
🚀 Launching mainnet environment
🌍 Checking for updates ...
```

#### Syncing indicator
```
Syncing light clients:
┌─────────┬─────────────────────────────────────────────────────┐
│ SERVICE │ STATUS                                              │
├─────────┼─────────────────────────────────────────────────────┤
│ lndbtc  │ Syncing 34.24% (610000/1781443)                     │
├─────────┼─────────────────────────────────────────────────────┤
│ lndltc  │ Syncing 12.17% (191000/1568645)                     │
└─────────┴─────────────────────────────────────────────────────┘
```

#### Wallet setup question

```
Do you want to create a new opendexd environment or restore an existing one?
1) Create New
2) Restore Existing
Please choose: 1
```

```
You are creating an opendexd node key and underlying wallets. All will be secured by a single password provided below.

Enter a password: 
Re-enter password: 

----------------------BEGIN OPENDEX SEED---------------------
 1. you         2. won't       3. find        4. money      
 5. in          6. this        7. seed        8. but    
 9. good       10. thinking   11. if         12. you      
13. are        14. interested 15. in         16. getting     
17. rewarded   18. for        19. testing    20. opendex  
21. security   22. hit        23. us         24. up   
-----------------------END OPENDEX SEED----------------------

The following wallets were initialized: BTC, LTC, ERC20(ETH)
```

#### Auto-unlock question


#### Backup setup question

```
Please enter a path to a destination where to store a backup of your environment. It includes everything, but NOT your on-chain wallet balance which is secured by your opendexd SEED. The path should be an external drive, like a USB or network drive, which is permanently available on your device since backups are written constantly.

Enter path to backup location: /media/USB/
Checking... OK.
```

#### The most familiar console

```
mainnet > status
┌───────────┬────────────────────────────────────────────────┐
│ SERVICE   │ STATUS                                         │
├───────────┼────────────────────────────────────────────────┤
│ bitcoind  │ Ready (light mode)                             │
├───────────┼────────────────────────────────────────────────┤
│ litecoind │ Ready (light mode)                             │
├───────────┼────────────────────────────────────────────────┤
│ geth      │ Ready (light mode)                             │
├───────────┼────────────────────────────────────────────────┤
│ lndbtc    │ Syncing                                        │
├───────────┼────────────────────────────────────────────────┤
│ lndltc    │ Syncing                                        │
├───────────┼────────────────────────────────────────────────┤
│ connext   │ Ready                                          │
├───────────┼────────────────────────────────────────────────┤
│ opendexd  │ Waiting for lndbtc, lndltc                     │
└───────────┴────────────────────────────────────────────────┘
```

### 2. Which issues (if any) are related?

Close #7.

### 3. Which documentation changes (if any) need to be made?

https://opendex.network/docs/swap-providers#lets-roll

Single line bootstrap command
```
curl -sfL https://raw.githubusercontent.com/opendexnetwork/opendex-docker/master/opendex.sh | sh
```

### 4. Does this introduce a backward incompatible change or deprecation?

It may affects the old non-interactive setup flow.
